### PR TITLE
Hide location name when it overlaps machine count on map

### DIFF
--- a/app/components/CustomMapMarkers.js
+++ b/app/components/CustomMapMarkers.js
@@ -61,7 +61,15 @@ const CustomMapMarkers = React.memo(() => {
         dispatch(setSelectedMapLocation(Number(e.features[0].id)));
       }}
     >
+      <Mapbox.SymbolLayer
+        id={"symbol-id2"}
+        style={textFloat(theme.theme)}
+        minZoomLevel={11}
+        maxZoomLevel={24}
+      />
+
       <Mapbox.SymbolLayer id={"symbol-id1"} style={iconStyles} />
+
       <Mapbox.Images
         images={{
           one: require("../assets/marker-one.png"),
@@ -71,12 +79,6 @@ const CustomMapMarkers = React.memo(() => {
           oneSelected: require("../assets/marker-one-selected.png"),
           moreOneSelected: require("../assets/marker-more-selected.png"),
         }}
-      />
-      <Mapbox.SymbolLayer
-        id={"symbol-id2"}
-        style={textFloat(theme.theme)}
-        minZoomLevel={11}
-        maxZoomLevel={24}
       />
     </Mapbox.ShapeSource>
   );


### PR DESCRIPTION
# Overview
Attempts to fix #540. Just tried what @RyanTG had already suggested and it seems to work (in a single case):
> Perhaps changing the order of the symbollayers will help.

I haven't really tested this, but I'll play around with the app some more. Would an automated test be needed? Seems like it'd be a little involved.

# Changes
- Render location name before machine count to hide on overlap

## Before
![image](https://github.com/user-attachments/assets/e288a9f0-bdd8-4d8d-b4bb-9f51508f41d2)

## After
![image](https://github.com/user-attachments/assets/dcaac818-01ad-4eb2-94fe-ac38eea70005)

# Notes
- Warning is shown after the text `SymbolLayer` is moved, something about the ID changing:  
`WARN  Mapbox [warning] Changing id from: symbol-id1 to symbol-id2, changing of id is supported`. However, this goes away once the app is reloaded.

