### PR TITLE
Refactored settings button groups to be a common component

### DIFF
--- a/app/screens/Settings.js
+++ b/app/screens/Settings.js
@@ -48,53 +48,56 @@ const Settings = ({ user, setUnitPreference }) => {
     setUnitPreference(idx);
   };
 
+  const ButtonGroupSetting = ({
+    title,
+    buttons,
+    description,
+    onPress,
+    selectedIndex,
+  }) => {
+    return (
+      <View>
+        <View style={s.pageTitle}>
+          <Text style={s.pageTitleText}>{title}</Text>
+        </View>
+        <ButtonGroup
+          onPress={onPress}
+          selectedIndex={selectedIndex}
+          buttons={buttons}
+          containerStyle={s.buttonGroupContainer}
+          textStyle={s.buttonGroupInactive}
+          selectedButtonStyle={s.selButtonStyle}
+          selectedTextStyle={s.selTextStyle}
+          innerBorderStyle={s.innerBorderStyle}
+        />
+        <Text style={s.text}>{description}</Text>
+      </View>
+    );
+  };
+
   return (
     <Screen>
       <View style={s.background}>
-        <View style={s.pageTitle}>
-          <Text style={s.pageTitleText}>Light Mode Theme</Text>
-        </View>
-        <ButtonGroup
+        <ButtonGroupSetting
+          title="Light Mode Theme"
+          buttons={["Light", "Dark"]}
+          description="When your phone is in Light Mode, use our Light theme or our Dark theme."
           onPress={updateDefaultPref}
           selectedIndex={selectedDefault}
-          buttons={["Light", "Dark"]}
-          containerStyle={s.buttonGroupContainer}
-          textStyle={s.buttonGroupInactive}
-          selectedButtonStyle={s.selButtonStyle}
-          selectedTextStyle={s.selTextStyle}
-          innerBorderStyle={s.innerBorderStyle}
         />
-        <Text
-          style={s.text}
-        >{`When your phone is in Light Mode, use our Light theme or our Dark theme.`}</Text>
-        <View style={s.pageTitle}>
-          <Text style={s.pageTitleText}>Dark Mode Theme</Text>
-        </View>
-        <ButtonGroup
+        <ButtonGroupSetting
+          title="Dark Mode Theme"
+          buttons={["Light", "Dark"]}
+          description="When your phone is in Dark Mode, stick with a Dark theme or switch to Light theme."
           onPress={updateDarkPref}
           selectedIndex={selectedDark}
-          buttons={["Light", "Dark"]}
-          containerStyle={s.buttonGroupContainer}
-          textStyle={s.buttonGroupInactive}
-          selectedButtonStyle={s.selButtonStyle}
-          selectedTextStyle={s.selTextStyle}
-          innerBorderStyle={s.innerBorderStyle}
         />
-        <Text
-          style={s.text}
-        >{`When your phone is in Dark Mode, stick with a Dark theme or switch to Light theme.`}</Text>
-        <View style={s.pageTitle}>
-          <Text style={s.pageTitleText}>Distance Unit</Text>
-        </View>
-        <ButtonGroup
+        <ButtonGroupSetting
+          title="Distance Unit"
+          buttons={["Miles", "Kilometers"]}
+          description="Choose your preferred distance measurement unit."
           onPress={updateUnitPref}
           selectedIndex={user.unitPreference ? 1 : 0}
-          buttons={["Miles", "Kilometers"]}
-          containerStyle={s.buttonGroupContainer}
-          textStyle={s.buttonGroupInactive}
-          selectedButtonStyle={s.selButtonStyle}
-          selectedTextStyle={s.selTextStyle}
-          innerBorderStyle={s.innerBorderStyle}
         />
       </View>
     </Screen>

--- a/app/screens/Settings.js
+++ b/app/screens/Settings.js
@@ -8,9 +8,10 @@ import { ThemeContext } from "../theme-context";
 import { Screen, Text } from "../components";
 import { retrieveItem } from "../config/utils";
 import { setUnitPreference } from "../actions";
-
-export const KEY_DEFAULT_THEME_OVERRIDE = "defaultThemeOverride";
-export const KEY_DARK_THEME_OVERRIDE = "darkThemeOverride";
+import {
+  KEY_DEFAULT_THEME_OVERRIDE,
+  KEY_DARK_THEME_OVERRIDE,
+} from "../utils/constants";
 
 const Settings = ({ user, setUnitPreference }) => {
   const { toggleDefaultTheme, toggleDarkTheme, theme } =

--- a/app/screens/Settings.js
+++ b/app/screens/Settings.js
@@ -9,6 +9,9 @@ import { Screen, Text } from "../components";
 import { retrieveItem } from "../config/utils";
 import { setUnitPreference } from "../actions";
 
+export const KEY_DEFAULT_THEME_OVERRIDE = "defaultThemeOverride";
+export const KEY_DARK_THEME_OVERRIDE = "darkThemeOverride";
+
 const Settings = ({ user, setUnitPreference }) => {
   const { toggleDefaultTheme, toggleDarkTheme, theme } =
     useContext(ThemeContext);
@@ -18,12 +21,12 @@ const Settings = ({ user, setUnitPreference }) => {
   const [selectedDark, updateSelectedDark] = useState(1);
 
   useEffect(() => {
-    retrieveItem("defaultThemeOverride").then(
+    retrieveItem(KEY_DEFAULT_THEME_OVERRIDE).then(
       (defaultThemeOverride) =>
         defaultThemeOverride && updateSelectedDefault(1),
     );
 
-    retrieveItem("darkThemeOverride").then(
+    retrieveItem(KEY_DARK_THEME_OVERRIDE).then(
       (darkThemeOverride) => darkThemeOverride && updateSelectedDark(0),
     );
   });
@@ -32,7 +35,7 @@ const Settings = ({ user, setUnitPreference }) => {
     if (idx === selectedDefault) return;
 
     updateSelectedDefault(idx);
-    AsyncStorage.setItem("defaultThemeOverride", JSON.stringify(idx === 1));
+    AsyncStorage.setItem(KEY_DEFAULT_THEME_OVERRIDE, JSON.stringify(idx === 1));
     toggleDefaultTheme();
   };
 
@@ -40,7 +43,7 @@ const Settings = ({ user, setUnitPreference }) => {
     if (idx === selectedDark) return;
 
     updateSelectedDark(idx);
-    AsyncStorage.setItem("darkThemeOverride", JSON.stringify(idx === 0));
+    AsyncStorage.setItem(KEY_DARK_THEME_OVERRIDE, JSON.stringify(idx === 0));
     toggleDarkTheme();
   };
 

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,0 +1,2 @@
+export const KEY_DEFAULT_THEME_OVERRIDE = "defaultThemeOverride";
+export const KEY_DARK_THEME_OVERRIDE = "darkThemeOverride";

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ import * as Device from "expo-device";
 import {
   KEY_DARK_THEME_OVERRIDE,
   KEY_DEFAULT_THEME_OVERRIDE,
-} from "./app/screens/Settings";
+} from "./app/utils/constants";
 
 Sentry.init({
   dsn: "https://057bae9b04f2410db6e4f1bd8d3eff2c@o1352308.ingest.sentry.io/6633526",

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ import { AppWrapper } from "./app/components";
 import MapNavigator from "./app/config/router";
 import * as Sentry from "@sentry/react-native";
 import * as Device from "expo-device";
+import {
+  KEY_DARK_THEME_OVERRIDE,
+  KEY_DEFAULT_THEME_OVERRIDE,
+} from "./app/screens/Settings";
 
 Sentry.init({
   dsn: "https://057bae9b04f2410db6e4f1bd8d3eff2c@o1352308.ingest.sentry.io/6633526",
@@ -42,14 +46,14 @@ const App = () => {
   );
 
   useEffect(() => {
-    retrieveItem("defaultThemeOverride").then(
+    retrieveItem(KEY_DEFAULT_THEME_OVERRIDE).then(
       (defaultThemeOverride) =>
         defaultTheme !== "dark" &&
         defaultThemeOverride &&
         setSelectedTheme("dark"),
     );
 
-    retrieveItem("darkThemeOverride").then(
+    retrieveItem(KEY_DARK_THEME_OVERRIDE).then(
       (darkThemeOverride) =>
         defaultTheme === "dark" && darkThemeOverride && setSelectedTheme(""),
     );


### PR DESCRIPTION
* Reduced code duplication by moving the common components of each setting into something that can be reused.
* Also extracted the setting keys to constants for the theme related settings. This should make it a little less risky if we wind up changing the keys, or this pattern is copied in the future.

In preparation for a few upcoming PRs that will likely include more settings. 

Easiest to understand by using the split diff view.

Note: Not a react native developer so please let me know if I'm using any poor practices. I touch RN once every couple of years, so it's been a while.

| Old Look    | New Look |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/4eb742bf-2cd5-4996-b1d1-2d43e190c6a3)  |  ![image](https://github.com/user-attachments/assets/8f74ea0a-e7e0-4ef7-9fa3-88aa32d10ab2)   |
